### PR TITLE
13-편지 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/hoonsletter_back_springboot/repository/LetterRepository.java
+++ b/src/main/java/com/example/hoonsletter_back_springboot/repository/LetterRepository.java
@@ -4,5 +4,5 @@ import com.example.hoonsletter_back_springboot.domain.Letter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LetterRepository extends JpaRepository<Letter, Long> {
-
+  void deleteByIdAndUserAccount_Username(Long id, String username);
 }

--- a/src/main/java/com/example/hoonsletter_back_springboot/service/LetterService.java
+++ b/src/main/java/com/example/hoonsletter_back_springboot/service/LetterService.java
@@ -43,7 +43,7 @@ public class LetterService {
 
     }
     letter.setLetterScenes(letterScenes);
-    letterRepository.save(letter);
+    Letter savedLetter = letterRepository.save(letter);
   }
 
   @Transactional(readOnly = true)
@@ -51,6 +51,11 @@ public class LetterService {
     return letterRepository.findById(letterId)
         .map(LetterDto::from)
         .orElseThrow(() -> new EntityNotFoundException("편지를 찾을 수 없습니다 - letterId: " + letterId));
+  }
+
+  public void deleteLetter(Long letterId, String username) {
+    letterRepository.deleteByIdAndUserAccount_Username(letterId, username);
+    letterRepository.flush();
   }
 
   private static LetterScene createLetterScene(LetterSceneDto sceneDto, Letter letter) {

--- a/src/test/java/com/example/hoonsletter_back_springboot/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/example/hoonsletter_back_springboot/repository/JpaRepositoryTest.java
@@ -16,11 +16,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 @DisplayName("JPA 연결 테스트")
 @DataJpaTest
 class JpaRepositoryTest {
-  private final UserAccountRepository userAccountRepository;
-  private final LetterRepository letterRepository;
-  private final LetterSceneRepository letterSceneRepository;
-  private final SceneMessageRepository sceneMessageRepository;
-  private final ScenePictureRepository scenePictureRepository;
+  final UserAccountRepository userAccountRepository;
+  final LetterRepository letterRepository;
+  final LetterSceneRepository letterSceneRepository;
+  final SceneMessageRepository sceneMessageRepository;
+  final ScenePictureRepository scenePictureRepository;
 
   JpaRepositoryTest(
       @Autowired UserAccountRepository userAccountRepository,

--- a/src/test/java/com/example/hoonsletter_back_springboot/service/LetterServiceTest.java
+++ b/src/test/java/com/example/hoonsletter_back_springboot/service/LetterServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 
 import com.example.hoonsletter_back_springboot.domain.Letter;
 import com.example.hoonsletter_back_springboot.domain.LetterScene;
@@ -96,18 +97,6 @@ class LetterServiceTest {
     then(letterRepository).should().findById(letterId);
   }
 
-  Letter createLetter(String username) {
-    UserAccount user = createUser(username);
-    LetterDto letterDto = createLetterDto(user.getUsername());
-    return Letter.of(
-        letterDto.title(),
-        letterDto.letterType(),
-        letterDto.updatable(),
-        letterDto.thumbnailUrl(),
-        user
-    );
-  }
-
   @DisplayName("id에 대한 편지 정보가 없으면 예외를 던진다.")
   @Test
   void givenNonexistentLetterId_whenSearching_thenThrowsException() {
@@ -123,6 +112,35 @@ class LetterServiceTest {
         .isInstanceOf(EntityNotFoundException.class)
         .hasMessage("편지를 찾을 수 없습니다 - letterId: " + letterId);
     then(letterRepository).should().findById(letterId);
+  }
+
+  @DisplayName("편지의 id와 유저 아이디를 입력하면 편지를 삭제한다.")
+  @Test
+  void givenLetterIdAndUsername_whenDeleting_thenDeletesLetter(){
+    // Given
+    Long letterId = 1L;
+    String username = "test1";
+    willDoNothing().given(letterRepository).deleteByIdAndUserAccount_Username(letterId, username);
+    willDoNothing().given(letterRepository).flush();
+
+    // When
+    sut.deleteLetter(letterId, username);
+
+    // Then
+    then(letterRepository).should().deleteByIdAndUserAccount_Username(letterId, username);
+    then(letterRepository).should().flush();
+  }
+
+  Letter createLetter(String username) {
+    UserAccount user = createUser(username);
+    LetterDto letterDto = createLetterDto(user.getUsername());
+    return Letter.of(
+        letterDto.title(),
+        letterDto.letterType(),
+        letterDto.updatable(),
+        letterDto.thumbnailUrl(),
+        user
+    );
   }
 
   LetterDto createLetterDto(String username) {

--- a/src/test/java/com/example/hoonsletter_back_springboot/service/LetterServiceTest.java
+++ b/src/test/java/com/example/hoonsletter_back_springboot/service/LetterServiceTest.java
@@ -39,18 +39,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LetterServiceTest {
 
   @InjectMocks
-  private LetterService sut;
+  LetterService sut;
 
   @Mock
-  private LetterRepository letterRepository;
+  LetterRepository letterRepository;
   @Mock
-  private UserAccountRepository userAccountRepository;
+  UserAccountRepository userAccountRepository;
   @Mock
-  private LetterSceneRepository letterSceneRepository;
+  LetterSceneRepository letterSceneRepository;
   @Mock
-  private SceneMessageRepository sceneMessageRepository;
+  SceneMessageRepository sceneMessageRepository;
   @Mock
-  private ScenePictureRepository scenePictureRepository;
+  ScenePictureRepository scenePictureRepository;
 
   @DisplayName("편지 정보를 입력하면 편지를 저장합니다.")
   @Test


### PR DESCRIPTION
편지 삭제를 위한 기능을 구현하고 테스트 케이스를 추가함.
삭제를 위해 편지 id, username이 일치해야함.
username을 받기 위해 SecurityConfig를 추가할 예정임.

this closes #13 